### PR TITLE
Replace UIKit import with Foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ system you're developing on.
 2. Add the following to your Cartfile:
 
 ```
-github "GEOSwift/geos" ~> 4.0.1
+github "GEOSwift/geos" ~> 4.0.2
 ```
 
 3. Finish updating your project by following the [typical Carthage

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.0.1</string>
+	<string>4.0.2</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/Resources/geos.h
+++ b/Resources/geos.h
@@ -1,15 +1,4 @@
-#ifdef __OBJC__
-#import <UIKit/UIKit.h>
-#else
-#ifndef FOUNDATION_EXPORT
-#if defined(__cplusplus)
-#define FOUNDATION_EXPORT extern "C"
-#else
-#define FOUNDATION_EXPORT extern
-#endif
-#endif
-#endif
-
+@import Foundation;
 #import "geos_c.h"
 #import "export.h"
 

--- a/geos.podspec
+++ b/geos.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'geos'
-  s.version = '4.0.1'
+  s.version = '4.0.2'
   s.summary = 'GEOS (Geometry Engine - Open Source) is a C++ port of the Java Topology Suite (JTS).'
   s.homepage = 'http://trac.osgeo.org/geos'
   s.license = {


### PR DESCRIPTION
Importing UIKit was breaking things while adding macOS Carthage support to GEOSwift.